### PR TITLE
Update raw.py

### DIFF
--- a/raw/raw.py
+++ b/raw/raw.py
@@ -18,10 +18,10 @@ class EmbedRaw(commands.Cog):
         
         try:
             msg = await ctx.fetch_message(message_id)
-        except Exception as e:
-            print(str(e))
-        msgg = msg.embeds[0]
-        await ctx.send(f"```{msgg.description}```")
+        except commands.CommandInvokeError:
+            return await ctx.send("Message not found")
+
+        await ctx.send(f"```{msg.embeds[0].description}```")
         
 
 def setup(bot):


### PR DESCRIPTION
- Too broad exception clause. (`Exception` -> `commands.CommandInvokeError`)
- Unnecessary variable assignment. (`msgg` -> ` `)
- No response when invalid message ID is provided. (`print(str(e))` ->`return await ctx.send("Message not found")` )

#### Other issues:
- Add handler for messages without embeds in exception clause.